### PR TITLE
fix: add a sync-repo-settings file

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Whether or not rebase-merging is enabled on this repository.
+# Defaults to `true`
+rebaseMergeAllowed: true
+
+# Whether or not squash-merging is enabled on this repository.
+# Defaults to `true`
+squashMergeAllowed: true
+
+# Whether or not PRs are merged with a merge commit on this repository.
+# Defaults to `false`
+mergeCommitAllowed: false
+
+# Rules for main branch protection
+branchProtectionRules:
+# Identifies the protection rule pattern. Name of the branch to be protected.
+# Defaults to `main`
+- pattern: main
+  # Can admins overwrite branch protection.
+  # Defaults to `true`
+  isAdminEnforced: false
+  # Number of approving reviews required to update matching branches.
+  # Defaults to `1`
+  requiredApprovingReviewCount: 1
+  # Are reviews from code owners required to update matching branches.
+  # Defaults to `false`
+  requiresCodeOwnerReviews: true
+  # Require up to date branches
+  requiresStrictStatusChecks: false


### PR DESCRIPTION
I think these sets of settings restore being able to push to main. 